### PR TITLE
Add sleep syscall for Wren Core

### DIFF
--- a/src/fiberscript/vm.zig
+++ b/src/fiberscript/vm.zig
@@ -276,18 +276,25 @@ pub fn Engine(configuration: Configuration) type {
 }
 
 pub const SyscallContext = struct {
+    const Timer = struct {
+        fiber: *c.Handle,
+        deadline_ms: u64,
+    };
+
     allocator: std.mem.Allocator,
     document: *dom.Dom,
     window: ?*WindowMod.Window = null,
     viewport_width: usize = 80,
     viewport_height: usize = 24,
     frame_fibers: std.ArrayListUnmanaged(*c.Handle) = .{},
+    sleep_timers: std.ArrayListUnmanaged(Timer) = .{},
 
     pub fn deinit(self: *SyscallContext) void {
         if (self.window) |w| {
             w.deinit();
             self.allocator.destroy(w);
         }
+        self.sleep_timers.deinit(self.allocator);
     }
 };
 const Fiber = *c.Handle;
@@ -418,6 +425,15 @@ pub fn documentSyscalls(comptime EngineType: type, comptime Context: type) type 
             _ = engine; // autofix
             _ = args; // autofix
             try context.frame_fibers.append(context.allocator, fiber);
+            return syscalls.Pending{};
+        }
+
+        pub fn sleep(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { seconds: f64 }) anyerror!Pending {
+            _ = engine;
+            const now_ms = std.time.milliTimestamp();
+            const delay_ms = @as(i64, @intFromFloat(args.seconds * 1000.0));
+            const deadline: u64 = @intCast(now_ms + delay_ms);
+            try context.sleep_timers.append(context.allocator, .{ .fiber = fiber, .deadline_ms = deadline });
             return syscalls.Pending{};
         }
 

--- a/src/fiberscript/xtc.wren
+++ b/src/fiberscript/xtc.wren
@@ -18,6 +18,10 @@ class Core {
         args["operation"] = name
         return syscall(args)
     }
+
+    static sleep(seconds) {
+        return call("sleep", { "seconds": seconds })
+    }
 }
 
 class Document {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,7 @@ const ansi = @import("ansi");
 
 const vm = @import("fiberscript/vm.zig");
 const dom = @import("dom.zig");
+const c = @import("fiberscript/wren.zig");
 
 const Engine = vm.Engine(.{});
 const SyscallContext = vm.SyscallContext;
@@ -51,6 +52,29 @@ pub fn main() !void {
     return error.Usage;
 }
 
+pub fn driveTimers(engine: *Engine, sc: *SyscallContext) !void {
+    while (sc.sleep_timers.items.len > 0) {
+        var index: usize = 0;
+        var earliest = sc.sleep_timers.items[0].deadline_ms;
+        var i: usize = 1;
+        while (i < sc.sleep_timers.items.len) : (i += 1) {
+            const t = sc.sleep_timers.items[i];
+            if (t.deadline_ms < earliest) {
+                earliest = t.deadline_ms;
+                index = i;
+            }
+        }
+        const now: u64 = @intCast(std.time.milliTimestamp());
+        if (earliest > now) {
+            std.time.sleep((earliest - now) * std.time.ns_per_ms);
+        }
+        const timer = sc.sleep_timers.swapRemove(index);
+        var builder = engine.slots();
+        try builder.set(0, timer.fiber).call("call()").checkSuccess();
+        c.wrenReleaseHandle(engine.vm, timer.fiber);
+    }
+}
+
 fn run_script(allocator: std.mem.Allocator, name: []const u8) !void {
     var stderr = std.io.getStdErr().writer();
 
@@ -69,6 +93,7 @@ fn run_script(allocator: std.mem.Allocator, name: []const u8) !void {
 
     defer engine.croak() catch {};
     try engine.runTopLevel(name, script);
+    try driveTimers(engine, &sc);
 
     const output = try engine.takeOutput(allocator);
     defer allocator.free(output);

--- a/src/test/sleep.test.zig
+++ b/src/test/sleep.test.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const vm = @import("../fiberscript/vm.zig");
+const dom = @import("../dom.zig");
+const c = @import("../fiberscript/wren.zig");
+
+const Engine = vm.Engine(.{});
+const SyscallContext = vm.SyscallContext;
+
+test "sleep syscall schedules timer" {
+    const allocator = std.testing.allocator;
+
+    var document = try dom.Dom.init(allocator);
+    defer document.deinit();
+    var sc = SyscallContext{ .allocator = allocator, .document = document };
+
+    var engine = try Engine.init(allocator, .{ .syscall_context = &sc });
+    defer engine.deinit();
+
+    const before = std.time.milliTimestamp();
+    try engine.runTopLevel("test",
+        \\import "xtc" for Core
+        \\var f = Fiber.new {
+        \\  Core.sleep(0.1)
+        \\}
+        \\f.call()
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), sc.sleep_timers.items.len);
+    const timer = sc.sleep_timers.items[0];
+    const expected: u64 = @intCast(before + 100);
+    try std.testing.expect(timer.deadline_ms >= expected);
+
+    c.wrenReleaseHandle(engine.vm, timer.fiber);
+}
+
+test "sleep resumes fiber" {
+    const allocator = std.testing.allocator;
+
+    var document = try dom.Dom.init(allocator);
+    defer document.deinit();
+    var sc = SyscallContext{ .allocator = allocator, .document = document };
+
+    var engine = try Engine.init(allocator, .{ .syscall_context = &sc });
+    defer engine.deinit();
+
+    try engine.runTopLevel("test",
+        \\import "xtc" for Core
+        \\var f = Fiber.new {
+        \\  Core.sleep(0)
+        \\  Core.call("print", { "message": "done\\n" })
+        \\}
+        \\f.call()
+    );
+
+    try @import("../main.zig").driveTimers(engine, &sc);
+
+    const output = try engine.takeOutput(allocator);
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("done\n", output);
+}


### PR DESCRIPTION
## Summary
- add `Core.sleep(seconds)` in xtc.wren
- implement `sleep` syscall storing timers in context
- drive timer queue in `main.zig`
- test sleep scheduling and resumption

## Testing
- `CI=1 TERM=dumb zig build test --summary none`


------
https://chatgpt.com/codex/tasks/task_e_68a7c6a17b00832ca4441a8226260ee4