### PR TITLE
Add basic event loop with frame and input handling

### DIFF
--- a/demos/window.wren
+++ b/demos/window.wren
@@ -1,8 +1,11 @@
-import "xtc" for Core, Element, Text, Document
+import "xtc" for Core, Element, Text, Document, Window
 
 var body = Element.create("flex flex-col")
 var text = Text.create("Hello, World!")
 body.append(text)
 Document.root.append(body)
 Document.openWindow()
+
+Core.sleep(1)
+Window.close()
 

--- a/src/fiberscript/slots.zig
+++ b/src/fiberscript/slots.zig
@@ -64,7 +64,7 @@ pub const SlotBuilder = struct {
         defer self.allocator.free(cstr);
         try self.ensureSlots(slot + 3);
         _ = self.set(slot + 1, cstr);
-        try self.set(slot + 2, value);
+        _ = self.set(slot + 2, value);
         c.wrenSetMapValue(self.vm, slot, slot + 1, slot + 2);
     }
 

--- a/src/fiberscript/vm.zig
+++ b/src/fiberscript/vm.zig
@@ -288,6 +288,8 @@ pub const SyscallContext = struct {
     viewport_height: usize = 24,
     frame_fibers: std.ArrayListUnmanaged(*c.Handle) = .{},
     sleep_timers: std.ArrayListUnmanaged(Timer) = .{},
+    key_events: std.ArrayListUnmanaged(u8) = .{},
+    key_waiters: std.ArrayListUnmanaged(*c.Handle) = .{},
 
     pub fn deinit(self: *SyscallContext) void {
         if (self.window) |w| {
@@ -295,6 +297,8 @@ pub const SyscallContext = struct {
             self.allocator.destroy(w);
         }
         self.sleep_timers.deinit(self.allocator);
+        self.key_events.deinit(self.allocator);
+        self.key_waiters.deinit(self.allocator);
     }
 };
 const Fiber = *c.Handle;
@@ -359,6 +363,38 @@ pub fn documentSyscalls(comptime EngineType: type, comptime Context: type) type 
             }
             const stdout_writer = std.io.getStdOut().writer();
             try context.window.?.renderAndPresent(context.document, 0, stdout_writer);
+        }
+
+        pub fn closeWindow(engine: *EngineType, context: *Context, fiber: Fiber, args: struct {}) anyerror!void {
+            _ = fiber; // autofix
+            _ = args;
+            if (context.window) |w| {
+                w.deinit();
+                context.document.alloc.destroy(w);
+                context.window = null;
+            }
+
+            var i: usize = context.frame_fibers.items.len;
+            while (i > 0) : (i -= 1) {
+                const f = context.frame_fibers.items[i - 1];
+                c.wrenReleaseHandle(engine.vm, f);
+            }
+            context.frame_fibers.clearRetainingCapacity();
+
+            i = context.key_waiters.items.len;
+            while (i > 0) : (i -= 1) {
+                const f = context.key_waiters.items[i - 1];
+                c.wrenReleaseHandle(engine.vm, f);
+            }
+            context.key_waiters.clearRetainingCapacity();
+            context.key_events.clearRetainingCapacity();
+
+            i = context.sleep_timers.items.len;
+            while (i > 0) : (i -= 1) {
+                const t = context.sleep_timers.items[i - 1];
+                c.wrenReleaseHandle(engine.vm, t.fiber);
+            }
+            context.sleep_timers.clearRetainingCapacity();
         }
 
         pub fn printElement(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { nodeId: u32 }) anyerror!void {
@@ -434,6 +470,13 @@ pub fn documentSyscalls(comptime EngineType: type, comptime Context: type) type 
             const delay_ms = @as(i64, @intFromFloat(args.seconds * 1000.0));
             const deadline: u64 = @intCast(now_ms + delay_ms);
             try context.sleep_timers.append(context.allocator, .{ .fiber = fiber, .deadline_ms = deadline });
+            return syscalls.Pending{};
+        }
+
+        pub fn nextEvent(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { eventType: []const u8 }) anyerror!Pending {
+            _ = engine;
+            _ = args;
+            try context.key_waiters.append(context.allocator, fiber);
             return syscalls.Pending{};
         }
 

--- a/src/fiberscript/xtc.wren
+++ b/src/fiberscript/xtc.wren
@@ -36,6 +36,16 @@ class Document {
   }
 }
 
+class Window {
+  static nextEvent(type) {
+    return Core.call("nextEvent", { "eventType": type })
+  }
+
+  static close() {
+    return Core.call("closeWindow")
+  }
+}
+
 class Element {
   index { _index }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,26 +52,93 @@ pub fn main() !void {
     return error.Usage;
 }
 
-pub fn driveTimers(engine: *Engine, sc: *SyscallContext) !void {
-    while (sc.sleep_timers.items.len > 0) {
-        var index: usize = 0;
-        var earliest = sc.sleep_timers.items[0].deadline_ms;
-        var i: usize = 1;
-        while (i < sc.sleep_timers.items.len) : (i += 1) {
-            const t = sc.sleep_timers.items[i];
-            if (t.deadline_ms < earliest) {
-                earliest = t.deadline_ms;
-                index = i;
+pub fn eventLoop(engine: *Engine, sc: *SyscallContext) !void {
+    const frame_ns: u64 = std.time.ns_per_s / 60;
+    var next_frame = std.time.nanoTimestamp();
+
+    const stdin_file = std.io.getStdIn();
+    const handle = stdin_file.handle;
+
+    while (true) {
+        const now = std.time.nanoTimestamp();
+
+        if (sc.sleep_timers.items.len > 0) {
+            var index: usize = 0;
+            var earliest = sc.sleep_timers.items[0].deadline_ms;
+            var i: usize = 1;
+            while (i < sc.sleep_timers.items.len) : (i += 1) {
+                const t = sc.sleep_timers.items[i];
+                if (t.deadline_ms < earliest) {
+                    earliest = t.deadline_ms;
+                    index = i;
+                }
+            }
+            const now_ms: u64 = @intCast(@divTrunc(now, std.time.ns_per_ms));
+            if (earliest <= now_ms) {
+                const timer = sc.sleep_timers.swapRemove(index);
+                var builder = engine.slots();
+                try builder.set(0, timer.fiber).call("call()").checkSuccess();
+                c.wrenReleaseHandle(engine.vm, timer.fiber);
+                continue;
             }
         }
-        const now: u64 = @intCast(std.time.milliTimestamp());
-        if (earliest > now) {
-            std.time.sleep((earliest - now) * std.time.ns_per_ms);
+
+        var buf: [1]u8 = undefined;
+        var pfd = [1]std.posix.pollfd{.{ .fd = handle, .events = std.posix.POLL.IN, .revents = 0 }};
+        const poll_res = std.posix.poll(pfd[0..], 0) catch 0;
+        if (poll_res > 0 and (pfd[0].revents & std.posix.POLL.IN) != 0) {
+            const readn = std.posix.read(handle, buf[0..]) catch 0;
+            if (readn == 1) {
+                if (sc.key_waiters.items.len > 0) {
+                    const fiber = sc.key_waiters.swapRemove(sc.key_waiters.items.len - 1);
+                    var builder = engine.slots();
+                    _ = builder.set(0, fiber);
+                    c.wrenEnsureSlots(engine.vm, 2);
+                    c.wrenSetSlotNewMap(engine.vm, 1);
+                    try builder.mapSet(1, "type", "keypress");
+                    try builder.mapSet(1, "key", buf[0..1]);
+                    try builder.call("call(_)").checkSuccess();
+                    c.wrenReleaseHandle(engine.vm, fiber);
+                } else {
+                    try sc.key_events.append(sc.allocator, buf[0]);
+                }
+            }
+        } else if (sc.key_events.items.len > 0 and sc.key_waiters.items.len > 0) {
+            const key = sc.key_events.swapRemove(sc.key_events.items.len - 1);
+            const fiber = sc.key_waiters.swapRemove(sc.key_waiters.items.len - 1);
+            var builder = engine.slots();
+            _ = builder.set(0, fiber);
+            c.wrenEnsureSlots(engine.vm, 2);
+            c.wrenSetSlotNewMap(engine.vm, 1);
+            var k: [1]u8 = .{key};
+            try builder.mapSet(1, "type", "keypress");
+            try builder.mapSet(1, "key", k[0..1]);
+            try builder.call("call(_)").checkSuccess();
+            c.wrenReleaseHandle(engine.vm, fiber);
         }
-        const timer = sc.sleep_timers.swapRemove(index);
-        var builder = engine.slots();
-        try builder.set(0, timer.fiber).call("call()").checkSuccess();
-        c.wrenReleaseHandle(engine.vm, timer.fiber);
+
+        if (now >= next_frame) {
+            if (sc.frame_fibers.items.len > 0) {
+                var i: usize = sc.frame_fibers.items.len;
+                while (i > 0) : (i -= 1) {
+                    const fiber = sc.frame_fibers.swapRemove(i - 1);
+                    var builder = engine.slots();
+                    try builder.set(0, fiber).call("call()").checkSuccess();
+                    c.wrenReleaseHandle(engine.vm, fiber);
+                }
+            }
+            if (sc.window) |w| {
+                const stdout_writer = std.io.getStdOut().writer();
+                try w.renderAndPresent(sc.document, 0, stdout_writer);
+            }
+            next_frame += frame_ns;
+        }
+
+        if (sc.window == null and sc.sleep_timers.items.len == 0 and sc.frame_fibers.items.len == 0 and sc.key_waiters.items.len == 0 and sc.key_events.items.len == 0) {
+            break;
+        }
+
+        std.time.sleep(std.time.ns_per_ms);
     }
 }
 
@@ -93,7 +160,7 @@ fn run_script(allocator: std.mem.Allocator, name: []const u8) !void {
 
     defer engine.croak() catch {};
     try engine.runTopLevel(name, script);
-    try driveTimers(engine, &sc);
+    try eventLoop(engine, &sc);
 
     const output = try engine.takeOutput(allocator);
     defer allocator.free(output);


### PR DESCRIPTION
## Summary
- implement 60fps event loop with key input processing
- expose Window.nextEvent syscall and Wren binding
- add Window.close to clean up and exit the loop
- fix SlotBuilder mapSet helper

## Testing
- `zig build --summary none --color off`
- `zig build test --summary none --color off`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd8ef14c832c8f59ad2bd63b8289