### PR TITLE
Document no-progress builds and pre-build in setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@
 
 ## Build, Test, Develop
 
-- Bootstrap: `./scripts/setup.sh` installs the expected Zig and Bun if needed.
-- Build: `zig build --summary new` for a persistent progress view. `make` maps to this.
-- Test: `zig build test --summary new` runs inline + integration tests. `make test` maps to this.
+- Bootstrap: `./scripts/setup.sh` installs the expected Zig and Bun if needed and runs an initial `zig build`.
+- Build: `ZIG_NO_PROGRESS=1 zig build --summary new` for a clean, non-interactive log (`ZIG_NO_PROGRESS` disables the progress bar). `ZIG_NO_PROGRESS=1 make` maps to this.
+- Test: `ZIG_NO_PROGRESS=1 zig build test --summary new` runs inline + integration tests. `ZIG_NO_PROGRESS=1 make test` maps to this.
 - Run: after building, use `zig-out/bin/xtc` (see `--help` and `README.md` for flags and examples).
 
 ## Coding Style

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -159,4 +159,19 @@ else
   info "Found bun on PATH ($(command -v bun))"
 fi
 
+# Perform an initial build to warm caches and verify the toolchain
+zig_bin="$(command -v zig 2>/dev/null || true)"
+if [[ -z "$zig_bin" ]]; then
+  zig_candidate="$VENDOR_DIR/zig/zig"
+  if [[ -x "$zig_candidate" ]]; then
+    zig_bin="$zig_candidate"
+  fi
+fi
+if [[ -n "$zig_bin" ]]; then
+  info "Running initial zig build"
+  (cd "$REPO_ROOT" && ZIG_NO_PROGRESS=1 "$zig_bin" build --summary new)
+else
+  warn "zig not found; skipping initial build"
+fi
+
 info "Setup complete."


### PR DESCRIPTION
## Summary
- document disabling Zig's progress UI via `ZIG_NO_PROGRESS=1`
- run an initial `zig build --summary new` in `scripts/setup.sh`

## Testing
- `ZIG_NO_PROGRESS=1 zig build --summary new`
- `ZIG_NO_PROGRESS=1 zig build test --summary new`


------
https://chatgpt.com/codex/tasks/task_e_68a7d304d5ec832c9e6039175949a0ef