### PR TITLE
Add filesystem I/O syscalls and fs Wren module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 ## Build, Test, Develop
 
 - Bootstrap: `./scripts/setup.sh` installs the expected Zig and Bun if needed and runs an initial `zig build`.
-- Build: `ZIG_NO_PROGRESS=1 zig build --summary new` for a clean, non-interactive log (`ZIG_NO_PROGRESS` disables the progress bar). `ZIG_NO_PROGRESS=1 make` maps to this.
-- Test: `ZIG_NO_PROGRESS=1 zig build test --summary new` runs inline + integration tests. `ZIG_NO_PROGRESS=1 make test` maps to this.
+- Build: `TERM=dumb ZIG_NO_PROGRESS=1 zig build --summary new` for a clean, non-interactive log (`TERM=dumb` and `ZIG_NO_PROGRESS` disable terminal control sequences). `ZIG_NO_PROGRESS=1 make` maps to this.
+- Test: `TERM=dumb ZIG_NO_PROGRESS=1 zig build test --summary new` runs inline + integration tests. `ZIG_NO_PROGRESS=1 make test` maps to this.
 - Run: after building, use `zig-out/bin/xtc` (see `--help` and `README.md` for flags and examples).
 
 ## Coding Style
@@ -18,6 +18,7 @@
 - Target Zig 0.14.x. Format with `zig fmt` before committing.
 - Prefer small, focused modules and clear names; keep helpers in `src/lib/` when shared.
 - Keep diffs tight and avoid drive‑by refactors in unrelated areas.
+- For Wren code, avoid single-line control flow like `if (...) return x`; use braces and newlines for all blocks.
 
 ## Testing
 

--- a/demos/fs_cat.wren
+++ b/demos/fs_cat.wren
@@ -1,0 +1,3 @@
+import "fs" for FS
+
+System.print(FS.read("README.md"))

--- a/demos/fs_list.wren
+++ b/demos/fs_list.wren
@@ -1,0 +1,13 @@
+import "fs" for FS
+
+fun walk(path) {
+  for (name in FS.list(path)) {
+    var child = path + "/" + name
+    System.print(child)
+    if (FS.isDir(child)) {
+      walk(child)
+    }
+  }
+}
+
+walk(".")

--- a/src/fiberscript/fs.wren
+++ b/src/fiberscript/fs.wren
@@ -1,0 +1,24 @@
+import "xtc" for Core
+import "syscall" for ReadFile, WriteFile, ReadDir, IsDir
+
+class FS {
+  static read(path) {
+    return Core.call(ReadFile.new(path))
+  }
+
+  static write(path, data) {
+    return Core.call(WriteFile.new(path, data))
+  }
+
+  static list(path) {
+    var result = Core.call(ReadDir.new(path))
+    if (result == "") {
+      return []
+    }
+    return result.split("\n")
+  }
+
+  static isDir(path) {
+    return Core.call(IsDir.new(path))
+  }
+}

--- a/src/fiberscript/syscalls.zig
+++ b/src/fiberscript/syscalls.zig
@@ -150,6 +150,23 @@ pub fn generateResultSetter(comptime Syscalls: type) type {
     };
 }
 
+pub fn generateResultFreer(comptime Syscalls: type, comptime Context: type) type {
+    const ResultType = ResultUnion(Syscalls);
+    return struct {
+        pub fn free(context: *Context, result: ResultType) void {
+            switch (result) {
+                inline else => |payload, tag| {
+                    _ = tag;
+                    const PayloadType = @TypeOf(payload);
+                    if (PayloadType == []const u8 or PayloadType == []u8) {
+                        context.allocator.free(@constCast(payload));
+                    }
+                },
+            }
+        }
+    };
+}
+
 /// Generate Wren source code defining foreign classes for each syscall payload.
 pub fn generateWrenModule(comptime Syscalls: type) []const u8 {
     const Request = RequestUnion(Syscalls);

--- a/src/fiberscript/vm.zig
+++ b/src/fiberscript/vm.zig
@@ -347,10 +347,12 @@ pub fn Engine(configuration: Configuration) type {
             var work = self.slots();
             const result = try self.dispatcher.dispatch(request, fiber);
             const setter = syscalls.generateResultSetter(SyscallsType);
+            const freer = syscalls.generateResultFreer(SyscallsType, SyscallContext);
             switch (result) {
                 .immediate => |x| {
                     defer c.wrenReleaseHandle(self.vm, fiber);
                     try setter.set(&work, 0, x);
+                    freer.free(self.syscall_context, x);
                 },
                 .pending => {
                     _ = work.set(0, fiber);
@@ -435,6 +437,7 @@ pub fn Engine(configuration: Configuration) type {
 
         fn bind(self: *Self) !void {
             try self.runTopLevel("xtc", @embedFile("xtc.wren"));
+            try self.runTopLevel("fs", @embedFile("fs.wren"));
         }
 
         pub fn takeOutput(self: *Self, allocator: std.mem.Allocator) ![]const u8 {
@@ -689,6 +692,46 @@ pub fn documentSyscalls(comptime EngineType: type, comptime Context: type) type 
             if (context.window) |w| {
                 try w.setViewport(context.viewport_width, context.viewport_height);
             }
+        }
+
+        pub fn readFile(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { path: []const u8 }) anyerror![]const u8 {
+            _ = engine;
+            _ = fiber;
+            return try std.fs.cwd().readFileAlloc(context.allocator, args.path, std.math.maxInt(usize));
+        }
+
+        pub fn writeFile(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { path: []const u8, data: []const u8 }) anyerror!void {
+            _ = engine;
+            _ = context;
+            _ = fiber;
+            try std.fs.cwd().writeFile(.{ .sub_path = args.path, .data = args.data });
+        }
+
+        pub fn readDir(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { path: []const u8 }) anyerror![]const u8 {
+            _ = engine;
+            _ = fiber;
+            var dir = try std.fs.cwd().openDir(args.path, .{ .iterate = true });
+            defer dir.close();
+            var list = std.ArrayList(u8).init(context.allocator);
+            var first = true;
+            var it = dir.iterate();
+            while (try it.next()) |entry| {
+                if (first) {
+                    first = false;
+                } else {
+                    try list.append('\n');
+                }
+                try list.appendSlice(entry.name);
+            }
+            return list.toOwnedSlice();
+        }
+
+        pub fn isDir(engine: *EngineType, context: *Context, fiber: Fiber, args: struct { path: []const u8 }) anyerror!bool {
+            _ = engine;
+            _ = fiber;
+            _ = context;
+            const stat = try std.fs.cwd().statFile(args.path);
+            return stat.kind == .directory;
         }
     };
 }

--- a/src/test/fs.test.zig
+++ b/src/test/fs.test.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const vm = @import("../fiberscript/vm.zig");
+const dom = @import("../dom.zig");
+
+const Engine = vm.Engine(.{});
+const SyscallContext = vm.SyscallContext;
+
+test "fs read write and list" {
+    const allocator = std.testing.allocator;
+
+    var document = try dom.Dom.init(allocator);
+    defer document.deinit();
+    var sc = SyscallContext{ .allocator = allocator, .document = document };
+
+    var engine = try Engine.init(allocator, .{ .syscall_context = &sc });
+    defer engine.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const file_path = try std.fs.path.join(allocator, &.{ dir_path, "sample.txt" });
+    defer allocator.free(file_path);
+
+    const script = try std.fmt.allocPrint(
+        allocator,
+        \\import "fs" for FS
+        \\var p = "{s}"
+        \\FS.write(p, "hi")
+        \\System.print(FS.read(p))
+        \\System.print(FS.list("{s}").contains("sample.txt"))
+    ,
+        .{ file_path, dir_path },
+    );
+    defer allocator.free(script);
+
+    try engine.runTopLevel("test", script);
+
+    const output = try engine.takeOutput(allocator);
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("hi\ntrue\n", output);
+}


### PR DESCRIPTION
## Summary
- add read, write, list and isDir filesystem syscalls
- expose filesystem helpers in new fs Wren module
- demonstrate filesystem use via tests and example scripts
- document TERM=dumb requirement for Zig builds and Wren block style guidance

## Testing
- `TERM=dumb ZIG_NO_PROGRESS=1 zig build --summary new`
- `TERM=dumb ZIG_NO_PROGRESS=1 zig build test --summary new`


------
https://chatgpt.com/codex/tasks/task_e_68a7eda76a4c832c823c6ada42d2fb3f