### PR TITLE
Refactor Wren DOM API

### DIFF
--- a/demos/hello.wren
+++ b/demos/hello.wren
@@ -1,4 +1,5 @@
-import "xtc" for Core, Element, Text, Document
+import "xtc" for Core
+import "dom" for Element, Text, Document
 
 var body = Element.create("flex flex-col")
 var text = Text.create("Hello, World!")

--- a/demos/window.wren
+++ b/demos/window.wren
@@ -1,11 +1,12 @@
-import "xtc" for Core, Element, Text, Document, Window
+import "xtc" for Core
+import "dom" for Element, Text, Document, Window
 
 var body = Element.create("flex flex-col")
 var text = Text.create("Hello, World!")
 body.append(text)
 Document.root.append(body)
-Document.openWindow()
+var win = Window.open()
 
 Core.sleep(1)
-Window.close()
+win.close()
 

--- a/src/fiberscript/dom.wren
+++ b/src/fiberscript/dom.wren
@@ -1,0 +1,67 @@
+import "xtc" for Core
+import "syscall" for OpenWindow, RequestRender, NextEvent, CloseWindow, CreateElement, AppendChild, UpdateClass, PrintElement, CreateText, UpdateText
+
+class Document {
+  static root { Element.fromIndex(0) }
+
+  static requestRender() {
+    return Core.call(RequestRender.new())
+  }
+}
+
+class Window {
+  construct new() {}
+
+  static open() {
+    Core.call(OpenWindow.new())
+    return Window.new()
+  }
+
+  nextEvent(type) {
+    return Core.call(NextEvent.new(type))
+  }
+
+  close() {
+    return Core.call(CloseWindow.new())
+  }
+}
+
+class Element {
+  index { _index }
+
+  construct fromIndex(index) {
+    _index = index
+  }
+
+  construct create(style) {
+    _index = Core.call(CreateElement.new(style))
+  }
+
+  append(child) {
+    return Core.call(AppendChild.new(index, child.index))
+  }
+
+  classes=(string) {
+    return Core.call(UpdateClass.new(index, string))
+  }
+
+  print() {
+    return Core.call(PrintElement.new(index))
+  }
+}
+
+class Text {
+  index { _index }
+
+  construct fromIndex(index) {
+    _index = index
+  }
+
+  construct create(text) {
+    _index = Core.call(CreateText.new(text))
+  }
+
+  content=(string) {
+    return Core.call(UpdateText.new(index, string))
+  }
+}

--- a/src/fiberscript/vm.zig
+++ b/src/fiberscript/vm.zig
@@ -437,6 +437,7 @@ pub fn Engine(configuration: Configuration) type {
 
         fn bind(self: *Self) !void {
             try self.runTopLevel("xtc", @embedFile("xtc.wren"));
+            try self.runTopLevel("dom", @embedFile("dom.wren"));
             try self.runTopLevel("fs", @embedFile("fs.wren"));
         }
 

--- a/src/fiberscript/xtc.wren
+++ b/src/fiberscript/xtc.wren
@@ -1,4 +1,4 @@
-import "syscall" for Sleep, OpenWindow, RequestRender, NextEvent, CloseWindow, CreateElement, AppendChild, UpdateClass, PrintElement, CreateText, UpdateText
+import "syscall" for Sleep
 
 class Core {
     foreign static syscall(fiber, request)
@@ -22,64 +22,3 @@ class Core {
     }
 }
 
-class Document {
-  static root { Element.fromIndex(0) }
-
-  static openWindow() {
-    return Core.call(OpenWindow.new())
-  }
-
-  static requestRender() {
-    return Core.call(RequestRender.new())
-  }
-}
-
-class Window {
-  static nextEvent(type) {
-    return Core.call(NextEvent.new(type))
-  }
-
-  static close() {
-    return Core.call(CloseWindow.new())
-  }
-}
-
-class Element {
-  index { _index }
-
-  construct fromIndex(index) {
-    _index = index
-  }
-
-  construct create(style) {
-    _index = Core.call(CreateElement.new(style))
-  }
-
-  append(child) {
-    return Core.call(AppendChild.new(index, child.index))
-  }
-
-  classes=(string) {
-    return Core.call(UpdateClass.new(index, string))
-  }
-
-  print() {
-    return Core.call(PrintElement.new(index))
-  }
-}
-
-class Text {
-  index { _index }
-
-  construct fromIndex(index) {
-    _index = index
-  }
-
-  construct create(text) {
-    _index = Core.call(CreateText.new(text))
-  }
-
-  content=(string) {
-    return Core.call(UpdateText.new(index, string))
-  }
-}

--- a/src/test/element_print.test.zig
+++ b/src/test/element_print.test.zig
@@ -16,7 +16,7 @@ test "Element#print prints the element's region" {
     defer engine.deinit();
 
     const script =
-        \\import "xtc" for Document, Element
+        \\import "dom" for Document, Element
         \\var a = Element.create("w-4 h-3 bg-glyph-[a]")
         \\var b = Element.create("w-4 h-3 bg-glyph-[b]")
         \\Document.root.classes = "flex flex-row items-start"


### PR DESCRIPTION
## Summary
- move DOM-related classes from `xtc.wren` into new `dom.wren`
- expose `Window.open()` returning a window object with instance `nextEvent` and `close`
- load `dom.wren` in the VM and update demos/tests for new imports

## Testing
- `zig build --summary new`
- `zig build test --summary new`


------
https://chatgpt.com/codex/tasks/task_e_68a7fea479dc832c8c171ddb50c86773